### PR TITLE
Add '&' before the restoration of cpoptions to make it work

### DIFF
--- a/plugin/fixkey.vim
+++ b/plugin/fixkey.vim
@@ -575,5 +575,5 @@ else
 endif
 
 " Restore saved 'cpoptions'.
-let cpoptions = s:save_cpoptions
+let &cpoptions = s:save_cpoptions
 " vim: sts=4 sw=4 tw=80 et ai:


### PR DESCRIPTION
The restoration of cpoptions was not working on FreeBSD 9.1 and ViM 7.3.1314
