### PR TITLE
Added support for screen-it and screen-256color-it (with italics)

### DIFF
--- a/plugin/fixkey.vim
+++ b/plugin/fixkey.vim
@@ -583,7 +583,7 @@ elseif $TERM =~# '^putty\(-\d*color\)\?$'
 elseif $TERM =~# '^rxvt\(-unicode\)\?\(-\d*color\)\?$'
     call Fixkey_setRxvtKeys()
 
-elseif $TERM =~# '^screen\(-\d*color\)\?\(-bce\)\?\(-s\)\?$'
+elseif $TERM =~# '^screen\(-\d*color\)\?\(-bce\|-it\)\?\(-s\)\?$'
     call Fixkey_setScreenKeys()
 
 else


### PR DESCRIPTION
The default screen/screen-256color termcap (which tmux uses) doesn't support italics, so programs end up assuming tmux is can't render them despite being capable of doing so. The suggested workaround on https://github.com/ThomasAdam/tmux/blob/master/FAQ is to patch support for italics into the screen/screen-256color termcap, and the suggested name for the new termcap is screen-it/screen-256color-it.

This patch adds support for screen-it and screen-256color-it to vim-fixkey.

Cheers!
