### PR TITLE
Alt-numbers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ Fixkey - fixes key codes for console Vim
 Fixkey helps Vim use the non-ASCII keys of a terminal emulator, permitting
 mapping of several classes of characters, including:
 
+- Alt-numbers (<M-0> - <M-9>).
 - Alt-lowercase letters (<M-a> - <M-z>).
 - Alt-uppercase letters (<M-A> - <M-Z>), except <M-O> due to keycode
   ambiguity).

--- a/plugin/fixkey.vim
+++ b/plugin/fixkey.vim
@@ -57,6 +57,14 @@ function! Fixkey_setNewKey(key, keyCode)
     let g:Fixkey_spareKeysUsed += 1
 endfunction
 
+function! Fixkey_setMetaNumbers()
+    let c = '0'
+    while c <= '9'
+        call Fixkey_setKey("<M-" .  c . ">", "\e" . c)
+        let c = nr2char(char2nr(c) + 1)
+    endwhile
+endfunction
+
 function! Fixkey_setMetaLetters()
     let c = 'a'
     while c <= 'z'
@@ -167,6 +175,7 @@ endfunction
 
 function! Fixkey_setXtermKeys()
     let g:Fixkey_termType = "xterm"
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setXtermFunctionKeys()
     call Fixkey_setXtermNavigationKeys()
@@ -179,6 +188,7 @@ endfunction
 
 function! Fixkey_setGnomeTerminalKeys()
     let g:Fixkey_termType = "gnome"
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setXtermFunctionKeys()
     call Fixkey_setXtermNavigationKeys()
@@ -188,6 +198,7 @@ endfunction
 
 function! Fixkey_setKonsoleKeys()
     let g:Fixkey_termType = "konsole"
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setXtermFunctionKeys()
     call Fixkey_setXtermNavigationKeys()
@@ -197,6 +208,7 @@ endfunction
 
 function! Fixkey_setLinuxKeys()
     let g:Fixkey_termType = "linux"
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setKey("<F1>",  "\e[[A")
     call Fixkey_setKey("<F2>",  "\e[[B")
@@ -302,6 +314,7 @@ endfunction
 function! Fixkey_setPuttyKeys()
     let g:Fixkey_termType = "putty"
     call Fixkey_unsetFunctionKeys()
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setPuttyF1toF12()
     call Fixkey_setPuttyShiftF3toF10()
@@ -397,6 +410,7 @@ endfunction
 function! Fixkey_setPuttyScoKeys()
     let g:Fixkey_termType = "putty-sco"
     call Fixkey_unsetFunctionKeys()
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setPuttyScoF1toF12()
     call Fixkey_setPuttyScoShiftF1toF12()
@@ -525,6 +539,7 @@ function! Fixkey_setRxvtKeys()
     set <Undo>=
     " <Help> is \e28~, which aliases <S-F5>.  Undefine it to avoid conflict.
     set <Help>=
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setRxvtShiftF3toF12()
     call Fixkey_setRxvtCtrlF1toF12()
@@ -551,6 +566,7 @@ function! Fixkey_setScreenExtraHomeEnd()
 endfunction
 
 function! Fixkey_setScreenCompatibleKeys()
+    call Fixkey_setMetaNumbers()
     call Fixkey_setMetaLetters()
     call Fixkey_setXtermFunctionKeys()
     call Fixkey_setXtermHomeEnd()


### PR DESCRIPTION
I wanted to use `<A-0>` to `<A-9>` and noticed that it's not handled.
Works for iTerm (`Fixkey_termType = "xterm"`), however, I don't know if it should be left out for some of the other `termType`s.