### PR TITLE
Fix some issues with VTE terminals and tmux

### DIFF
--- a/plugin/fixkey.vim
+++ b/plugin/fixkey.vim
@@ -638,7 +638,7 @@ function! Fixkey_setup()
         " "xterm".  This same logic is required for tmux to work correctly, but
         " Vim currently lacks support for it.  As a work-around for this
         " problem, we ensure 'ttymouse' is set correctly below.
-        set ttymouse=xterm
+        set ttymouse=sgr
 
     else
         let g:Fixkey_termType = "unknown"

--- a/plugin/fixkey.vim
+++ b/plugin/fixkey.vim
@@ -604,8 +604,10 @@ function! Fixkey_setup()
     if $TERM =~# '^xterm\(-\d*color\)\?$'
         if $COLORTERM == "gnome-terminal"
             call Fixkey_setGnomeTerminalKeys()
-        else
+        elseif $COLORTERM == ""
             call Fixkey_setXtermKeys()
+        else
+            let g:Fixkey_termType = "unknown"
         endif
 
     elseif $TERM =~# '^gnome\(-\d*color\)\?$'


### PR DESCRIPTION
This solves two problems I've been having:

1. VTE terminals that use xterm-256color (namely xfce4-terminal, I don't have gnome-terminal installed but assume it works as expected) has had an issue where the first key you hit does nothing, and this seemed to be the case when setting COLORTERM to gnome-terminal too. Skipping the functionality specific to gnome-terminal and xterm eliminates this issue.

2. The mouse couldn't click anything past the ~210th character in tmux, this turned out to be because the plugin was overriding my ttymouse=sgr setting. To keep consistent with the way the plugin worked before I updated xterm to sgr, though it might be more kosher to simply drop the declaration and let the user decide.